### PR TITLE
Use enums for event names

### DIFF
--- a/src/js/view/UserListMediator.js
+++ b/src/js/view/UserListMediator.js
@@ -9,6 +9,7 @@
 import {Mediator} from "@puremvc/puremvc-js-multicore-framework";
 import {ApplicationFacade} from "../ApplicationFacade";
 import {UserProxy} from "../model/UserProxy";
+import UserListEvents from "./events/UserListEvents";
 
 export class UserListMediator extends Mediator {
 
@@ -19,9 +20,9 @@ export class UserListMediator extends Mediator {
     constructor(component) {
         super(UserListMediator.NAME, component);
         this.listeners = {
-            [component.NEW]: event => this.onNew(event.detail),
-            [component.SELECT]: event => this.onSelect(event.detail),
-            [component.DELETE]: event => this.onDelete(event.detail)
+            [UserListEvents.NEW]: event => this.onNew(event.detail),
+            [UserListEvents.SELECT]: event => this.onSelect(event.detail),
+            [UserListEvents.DELETE]: event => this.onDelete(event.detail)
         };
     }
 

--- a/src/js/view/components/UserList.jsx
+++ b/src/js/view/components/UserList.jsx
@@ -10,6 +10,8 @@ import styles from "../../../css/list.module.css"
 import {useEffect, useMemo, useState} from "react";
 import {ApplicationConstants} from "../../ApplicationConstants";
 import {User} from "../../model/valueObject/User";
+import UserListEvents from "../events/UserListEvents";
+
 
 export const UserList = () => {
 
@@ -18,9 +20,6 @@ export const UserList = () => {
     const [error, setError] = useState(null);
 
     const component = useMemo(() => ({
-        NEW: "UserListNew",
-        SELECT: "UserListSelect",
-        DELETE: "UserListDelete",
 
         setUsers: setUsers,
         addUser: (user) => {
@@ -47,17 +46,17 @@ export const UserList = () => {
     }, [component]);
 
     const onNew = () => {
-        dispatchEvent(new CustomEvent(component.NEW, {detail: new User()}));
+        dispatchEvent(new CustomEvent(UserListEvents.NEW, {detail: new User()}));
         setSelectedUser(null);
     }
 
     const onSelect = (user) => {
-        dispatchEvent(new CustomEvent(component.SELECT, {detail: user}));
+        dispatchEvent(new CustomEvent(UserListEvents.SELECT, {detail: user}));
         setSelectedUser(user);
     }
 
     const onDelete = (user) => {
-        dispatchEvent(new CustomEvent(component.DELETE, {detail: user}))
+        dispatchEvent(new CustomEvent(UserListEvents.DELETE, {detail: user}))
         setUsers(state => state.filter(u => u.id !== user.id));
         setSelectedUser(null);
     }

--- a/src/js/view/events/UserListEvents.jsx
+++ b/src/js/view/events/UserListEvents.jsx
@@ -1,0 +1,18 @@
+/**
+ * Enum: UserListEvents
+ */
+
+class UserListEvents {}
+
+const BASE = "events/user/list/";
+UserListEvents.NEW      = BASE + "new";
+UserListEvents.SELECT   = BASE + "select";
+UserListEvents.DELETE   = BASE + "delete";
+
+UserListEvents.LIST     = [
+    UserListEvents.NEW,
+    UserListEvents.SELECT,
+    UserListEvents.DELETE
+];
+
+export default UserListEvents;

--- a/test/view/components/UserList.test.jsx
+++ b/test/view/components/UserList.test.jsx
@@ -13,6 +13,7 @@ import {ApplicationConstants} from "../../../src/js/ApplicationConstants.js";
 import {User} from "../../../src/js/model/valueObject/User.js";
 import {Department} from "../../../src/js/model/valueObject/Department.js";
 import {UserList} from "../../../src/js/view/components/UserList.jsx";
+import UserListEvents from "../../../src/js/view/events/UserListEvents";
 
 describe("UserList", () => {
 
@@ -38,9 +39,8 @@ describe("UserList", () => {
 
     it("should test UserListNew event", async () => {
         await new Promise(resolve => {
-            window.addEventListener(ApplicationConstants.USER_LIST_MOUNTED, event => {
-                const component = event.detail;
-                window.addEventListener(component.NEW, resolve, {once: true});
+            window.addEventListener(ApplicationConstants.USER_LIST_MOUNTED, () => {
+                window.addEventListener(UserListEvents.NEW, resolve, {once: true});
                 fireEvent.click(screen.getByText("Add"));
             }, {once: true});
             render(<UserList />);
@@ -100,7 +100,7 @@ describe("UserList", () => {
                 act(() => { component.addUser(larry) });
                 await waitFor(() => { expect(screen.getByText("lstooge")).toBeInTheDocument() });
 
-                window.addEventListener(component.SELECT, ({detail}) => {
+                window.addEventListener(UserListEvents.SELECT, ({detail}) => {
                     expect(detail.username).to.equal(larry.username);
                     resolve();
                 }, {once: true});
@@ -120,8 +120,8 @@ describe("UserList", () => {
                 act(() => { component.addUser(larry) });
                 await waitFor(() => { expect(screen.getByText("lstooge")).toBeInTheDocument() });
 
-                window.addEventListener(component.SELECT, async () => {
-                    window.addEventListener(component.DELETE, ({detail}) => { // delete
+                window.addEventListener(UserListEvents.SELECT, async () => {
+                    window.addEventListener(UserListEvents.DELETE, ({detail}) => { // delete
                         expect(detail.username).to.equal("lstooge");
                         resolve();
                     }, {once: true});


### PR DESCRIPTION
Doubling down on the UserList implementation, add enums as event name contract.

* In UserList.jsx
  - import UserListEvents
  - remove hardcoded event constants from memoized object
  - change event dispatchers to use UserListEvents for event names

* In UserList.test.jsx
  - import UserListEvents
  - change event listeners to use UserListEvents for event names

* In UserList.test.jsx
  - import UserListEvents
  - change event listeners list to use UserListEvents for event names

* Added view/components/events/UserListEvents.jsx
  - defines the event name constants for the UserList component